### PR TITLE
Add GraalVM native-image resource configuration

### DIFF
--- a/resources/META-INF/native-image/clj_docker_client/resource-config.json
+++ b/resources/META-INF/native-image/clj_docker_client/resource-config.json
@@ -1,0 +1,6 @@
+{
+  "resources": [
+    { "pattern": "clj_docker_client/api/.+\\.yaml" }
+  ],
+  "bundles": []
+}


### PR DESCRIPTION
See here:
https://www.graalvm.org/docs/reference-manual/native-image/#native-image-configuration

This allows users of the library to use it in `native-image` builds without specific configuration.