### PR TITLE
readme: add 'Create a network' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,17 @@ Takes another optional key `:throw-exception?`. Defaults to `false`. If set to t
                            :params {:id "conny"}})
 ```
 
+#### Creating a network
+```clojure
+
+(def networks (docker/client {:category    :networks
+                              :conn        {:uri "unix:///var/run/docker.sock"}
+                              :api-version "v1.40"}))
+
+(docker/invoke networks {:op     :NetworkCreate
+                         :params {:networkConfig {:Name "conny-network"}}})
+```
+
 #### Streaming logs
 ```clojure
 ; fn to react when data is available


### PR DESCRIPTION

Adds "Create a network" example code in "Sample code for common scenarios" section.

- from the issue https://github.com/into-docker/clj-docker-client/issues/40
- same as Pulling an image, Creating a container
- although this is not critical, but still, hope this small addition to readme saves someone some time and mood

*solution is not mine, take no credit, i'm a happy recipient
